### PR TITLE
feat: add clang-14 installation from Debian Bookworm

### DIFF
--- a/keploy-ci/Dockerfile
+++ b/keploy-ci/Dockerfile
@@ -22,6 +22,8 @@ RUN set -eux; \
     netcat-openbsd \
     sudo \
     build-essential \
+    gcc-aarch64-linux-gnu \
+    g++-aarch64-linux-gnu \
     linux-headers-$(dpkg --print-architecture) \
     coreutils \
     util-linux \
@@ -31,6 +33,15 @@ RUN set -eux; \
     iptables \
     uidmap \
     ; \
+    rm -rf /var/lib/apt/lists/*
+
+# Install clang-14 from Debian Bookworm (not available in Trixie)
+RUN set -eux; \
+    echo "deb http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list.d/bookworm.list; \
+    printf 'Package: *\nPin: release n=bookworm\nPin-Priority: 100\n\nPackage: clang-14 lib*clang*14* libllvm14* llvm-14*\nPin: release n=bookworm\nPin-Priority: 500\n' > /etc/apt/preferences.d/clang-14; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends clang-14; \
+    rm -f /etc/apt/sources.list.d/bookworm.list /etc/apt/preferences.d/clang-14; \
     rm -rf /var/lib/apt/lists/*
 
 # Install Docker Engine (dockerd + docker CLI + buildx plugin + containerd)


### PR DESCRIPTION
This pull request updates the `keploy-ci/Dockerfile` to improve cross-compilation support and ensure the availability of specific compiler toolchains. The main changes are the addition of cross-compilers for the ARM64 architecture and the installation of `clang-14` from the Debian Bookworm repository.

**Toolchain and compiler support:**

* Added `gcc-aarch64-linux-gnu` and `g++-aarch64-linux-gnu` packages to enable ARM64 cross-compilation.
* Installed `clang-14` from the Debian Bookworm repository (not available in Trixie), including proper apt source and pinning configuration to ensure only the necessary packages are pulled from Bookworm.