### PR TITLE
fix: ensure jq is installed in the Dockerfile for golangci-lint

### DIFF
--- a/keploy-ci-golint/Dockerfile
+++ b/keploy-ci-golint/Dockerfile
@@ -5,6 +5,7 @@ FROM public.ecr.aws/docker/library/golang:1.25-bookworm
 ARG GOLANGCI_LINT_VERSION=v2.9.0
 
 RUN set -eux; \
+    apt-get update && apt-get install -y --no-install-recommends jq && rm -rf /var/lib/apt/lists/*; \
     curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
       | sh -s -- -b /usr/local/bin "${GOLANGCI_LINT_VERSION}"; \
     golangci-lint --version


### PR DESCRIPTION
This pull request makes a minor update to the Dockerfile for `keploy-ci-golint` by installing the `jq` utility. This addition will allow for easier processing of JSON data within the container.

* Added installation of `jq` via `apt-get` in `keploy-ci-golint/Dockerfile` to support JSON manipulation in container workflows.