### PR TITLE
chore: bump Go to 1.26 across all CI images

### DIFF
--- a/keploy-ci-go-build/Dockerfile
+++ b/keploy-ci-go-build/Dockerfile
@@ -1,6 +1,6 @@
 # keploy-ci-go-build: Go + MinGW cross-compilers + MinIO client
 # Used by: go-test.yml download-and-build, prepare-and-run.yml build-and-upload-keploy
-FROM public.ecr.aws/docker/library/golang:1.25-bookworm
+FROM public.ecr.aws/docker/library/golang:1.26-bookworm
 
 RUN set -eux; \
     apt-get update; \

--- a/keploy-ci-golint/Dockerfile
+++ b/keploy-ci-golint/Dockerfile
@@ -1,6 +1,6 @@
 # keploy-ci-golint: Go + golangci-lint pre-installed
 # Used by: golangci-lint.yml
-FROM public.ecr.aws/docker/library/golang:1.25-bookworm
+FROM public.ecr.aws/docker/library/golang:1.26-bookworm
 
 ARG GOLANGCI_LINT_VERSION=v2.9.0
 

--- a/keploy-ci/Dockerfile
+++ b/keploy-ci/Dockerfile
@@ -6,7 +6,7 @@
 # Linux binaries with CGO_ENABLED=0.
 FROM public.ecr.aws/docker/library/debian:trixie-slim
 
-ARG GO_VERSION=1.25.7
+ARG GO_VERSION=1.26.1
 # Keep Docker "major.minor" aligned with the latest stable release.
 ARG DOCKER_MAJOR_MINOR=29.1
 # Provided automatically by BuildKit/buildx; fallback to dpkg when unset.


### PR DESCRIPTION
## Summary
- Bump Go version from 1.25 to 1.26 in all CI images
- `keploy-ci`: GO_VERSION 1.25.7 → 1.26.1
- `keploy-ci-go-build`: golang:1.25-bookworm → golang:1.26-bookworm
- `keploy-ci-golint`: golang:1.25-bookworm → golang:1.26-bookworm

## Why
keploy's `go.mod` now requires `go >= 1.26.0`. The current CI images ship Go 1.25.7, causing woodpecker `prepare-and-run` pipeline failures with:
```
go: go.mod requires go >= 1.26.0 (running go 1.25.7; GOTOOLCHAIN=local)
```

## Test plan
- [ ] Images build successfully
- [ ] `go version` inside built images shows 1.26.x
- [ ] Integrations woodpecker pipelines pass with new images