### PR TITLE
feat: add keploy-ci-azurecli image for Azure Blob Storage uploads

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -54,6 +54,12 @@ jobs:
           - context: ./keploy-ci-awscli
             tag-prefix: 'awscli-'
             arch: arm64
+          - context: ./keploy-ci-azurecli
+            tag-prefix: 'azurecli-'
+            arch: amd64
+          - context: ./keploy-ci-azurecli
+            tag-prefix: 'azurecli-'
+            arch: arm64
           # --- amd64-only images ---
           - context: ./keploy-ci-go-build
             tag-prefix: 'go-build-'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,9 @@ jobs:
           - context: ./keploy-ci-awscli
             tag-prefix: 'awscli-'
             platforms: linux/amd64,linux/arm64
+          - context: ./keploy-ci-azurecli
+            tag-prefix: 'azurecli-'
+            platforms: linux/amd64,linux/arm64
           # amd64-only (MinGW cross-compiler is x86-64 only)
           - context: ./keploy-ci-go-build
             tag-prefix: 'go-build-'

--- a/keploy-ci-azurecli/Dockerfile
+++ b/keploy-ci-azurecli/Dockerfile
@@ -1,5 +1,5 @@
 # keploy-ci-azurecli: Azure CLI + tar + gzip
 # Used by: release pipelines for artifact upload to Azure Blob Storage
-FROM mcr.microsoft.com/azure-cli:latest
+FROM mcr.microsoft.com/azure-cli:2.64.0-alpine
 
-RUN tdnf install -y tar gzip && tdnf clean all
+RUN apk add --no-cache tar gzip

--- a/keploy-ci-azurecli/Dockerfile
+++ b/keploy-ci-azurecli/Dockerfile
@@ -1,0 +1,5 @@
+# keploy-ci-azurecli: Azure CLI + tar + gzip
+# Used by: release pipelines for artifact upload to Azure Blob Storage
+FROM mcr.microsoft.com/azure-cli:latest
+
+RUN apk add --no-cache tar gzip

--- a/keploy-ci-azurecli/Dockerfile
+++ b/keploy-ci-azurecli/Dockerfile
@@ -1,5 +1,5 @@
 # keploy-ci-azurecli: Azure CLI + tar + gzip
 # Used by: release pipelines for artifact upload to Azure Blob Storage
-FROM mcr.microsoft.com/azure-cli:2.64.0-alpine
+FROM mcr.microsoft.com/azure-cli:latest
 
-RUN apk add --no-cache tar gzip
+RUN tdnf install -y tar gzip && tdnf clean all

--- a/keploy-ci-azurecli/Dockerfile
+++ b/keploy-ci-azurecli/Dockerfile
@@ -2,4 +2,4 @@
 # Used by: release pipelines for artifact upload to Azure Blob Storage
 FROM mcr.microsoft.com/azure-cli:latest
 
-RUN apk add --no-cache tar gzip
+RUN tdnf install -y tar gzip && tdnf clean all


### PR DESCRIPTION
Adds a new CI image based on mcr.microsoft.com/azure-cli:latest with tar and gzip, mirroring the existing keploy-ci-awscli pattern. Registers it in both the build-check and publish workflows.