### PR TITLE
feat(keploy-ci-java): bundle jattach v2.2 (multi-arch)

### DIFF
--- a/keploy-ci-java/Dockerfile
+++ b/keploy-ci-java/Dockerfile
@@ -1,6 +1,10 @@
 # keploy-ci-java: keploy-ci + Maven + JDK (DinD + eBPF capable)
-# Used by: java-linux.yml
+# Used by: java-linux.yml + keploy/enterprise release pipelines, which
+# stage the bundled jattach binaries from /opt/jattach/<arch>/jattach
+# into a multi-arch buildx context.
 FROM ghcr.io/keploy/keploy-ci:1.2.9
+
+ARG TARGETARCH
 
 RUN set -eux; \
     apt-get update; \
@@ -11,3 +15,29 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*; \
     java -version; \
     mvn -version
+
+# Pre-stage jattach v2.2 for both linux/amd64 and linux/arm64 so release
+# pipelines can `cp /opt/jattach/<arch>/jattach ./jattach-<arch>` without
+# re-downloading from upstream every build. SHA256s pinned against the
+# upstream-published v2.2 archives so an upstream replacement fails the
+# image build instead of silently shipping a different binary.
+ARG JATTACH_VERSION=v2.2
+ARG JATTACH_SHA256_AMD64=acd9e17f15749306be843df392063893e97bfecc5260eef73ee98f06e5cfe02f
+ARG JATTACH_SHA256_ARM64=288ae5ed87ee7fe0e608c06db5a23a096a6217c9878ede53c4e33710bdcaab51
+RUN set -eux; \
+    for spec in "amd64:linux-x64:${JATTACH_SHA256_AMD64}" \
+                "arm64:linux-arm64:${JATTACH_SHA256_ARM64}"; do \
+        out="${spec%%:*}"; rest="${spec#*:}"; \
+        upstream="${rest%%:*}"; sha="${rest#*:}"; \
+        mkdir -p "/opt/jattach/${out}"; \
+        curl -fsSL --retry 3 --retry-delay 2 \
+            -o /tmp/jattach.tgz \
+            "https://github.com/jattach/jattach/releases/download/${JATTACH_VERSION}/jattach-${upstream}.tgz"; \
+        echo "${sha}  /tmp/jattach.tgz" | sha256sum -c -; \
+        tar -xzOf /tmp/jattach.tgz jattach > "/opt/jattach/${out}/jattach"; \
+        chmod +x "/opt/jattach/${out}/jattach"; \
+        rm /tmp/jattach.tgz; \
+    done; \
+    ln -s "/opt/jattach/${TARGETARCH}/jattach" /usr/local/bin/jattach; \
+    /usr/local/bin/jattach 2>&1 | head -1 || true; \
+    ls -la /opt/jattach/amd64/ /opt/jattach/arm64/

--- a/keploy-ci-java/Dockerfile
+++ b/keploy-ci-java/Dockerfile
@@ -4,6 +4,8 @@
 # into a multi-arch buildx context.
 FROM ghcr.io/keploy/keploy-ci:1.2.9
 
+# Provided automatically by BuildKit/buildx; fallback to dpkg when unset
+# (legacy / `docker build` without --build-arg).
 ARG TARGETARCH
 
 RUN set -eux; \
@@ -38,6 +40,11 @@ RUN set -eux; \
         chmod +x "/opt/jattach/${out}/jattach"; \
         rm /tmp/jattach.tgz; \
     done; \
-    ln -s "/opt/jattach/${TARGETARCH}/jattach" /usr/local/bin/jattach; \
+    ARCH="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    case "$ARCH" in amd64|arm64) ;; *) echo "unsupported ARCH=$ARCH" >&2; exit 1 ;; esac; \
+    ln -s "/opt/jattach/${ARCH}/jattach" /usr/local/bin/jattach; \
+    test -x /opt/jattach/amd64/jattach; \
+    test -x /opt/jattach/arm64/jattach; \
+    test -x /usr/local/bin/jattach; \
     /usr/local/bin/jattach 2>&1 | head -1 || true; \
-    ls -la /opt/jattach/amd64/ /opt/jattach/arm64/
+    ls -la /opt/jattach/amd64/ /opt/jattach/arm64/ /usr/local/bin/jattach

--- a/keploy-ci-java/Dockerfile
+++ b/keploy-ci-java/Dockerfile
@@ -41,7 +41,7 @@ RUN set -eux; \
         rm /tmp/jattach.tgz; \
     done; \
     ARCH="${TARGETARCH:-$(dpkg --print-architecture)}"; \
-    case "$ARCH" in amd64|arm64) ;; *) echo "unsupported ARCH=$ARCH" >&2; exit 1 ;; esac; \
+    case "$ARCH" in amd64|arm64) ;; *) echo "unsupported ARCH='$ARCH' (supported: amd64, arm64). Build with BuildKit/buildx or pass --build-arg TARGETARCH=amd64|arm64." >&2; exit 1 ;; esac; \
     ln -s "/opt/jattach/${ARCH}/jattach" /usr/local/bin/jattach; \
     test -x /opt/jattach/amd64/jattach; \
     test -x /opt/jattach/arm64/jattach; \


### PR DESCRIPTION
## Summary
- Bake `jattach` v2.2 (both `linux-x64` and `linux-arm64`) into `keploy-ci-java` so the keploy/enterprise release pipelines stop re-downloading it from GitHub on every release build.
- Both binaries land under `/opt/jattach/<arch>/jattach`. `/usr/local/bin/jattach` is symlinked to the host-arch binary so the image is also natively usable.
- SHA256s are pinned per-arch (`acd9e17f…` amd64, `288ae5ed…` arm64) — an upstream tarball replacement fails the image build rather than silently shipping a different binary.

## Background
keploy/enterprise's release pipelines build a multi-arch `keploy/enterprise` image but, until [#1995](https://github.com/keploy/enterprise/pull/1995), didn't stage `jattach` at all — the v3.5.0 release tag failed at the buildx step (`"/jattach": not found`). #1995 fixes that by adding a per-pipeline curl + sha-verify of jattach v2.2.

This PR moves that responsibility one level up: by bundling jattach into the `keploy-ci-java` base image (which the release pipelines already use for the `build-jvm-attach-assets` step), the per-pipeline curl can be replaced with a simple `cp /opt/jattach/<arch>/jattach ./jattach-<arch>`. That:
- removes 2 GitHub downloads per release (1× per arch, ×4 release pipelines = up to 8/release)
- removes a network failure mode at release time
- centralizes the jattach version + checksum in one place

## Follow-up
Once a tagged `keploy-ci-java:java-1.2.27` (or whichever version cuts this) is published, a tiny follow-up on keploy/enterprise will drop `.ci/scripts/fetch-jattach.sh` in favor of a `cp` from the bundled location.

## Test plan
- [ ] `docker buildx build --platform linux/amd64,linux/arm64 -t keploy-ci-java:test ./keploy-ci-java` succeeds.
- [ ] `docker run --rm --platform linux/amd64 keploy-ci-java:test sh -c 'ls -la /opt/jattach/amd64 /opt/jattach/arm64 && file /opt/jattach/amd64/jattach /opt/jattach/arm64/jattach'` shows x86-64 + ARM aarch64 ELFs.
- [ ] `docker run --rm --platform linux/amd64 keploy-ci-java:test jattach 2>&1 | head -1` prints jattach usage (proves the symlink is wired up correctly).