### PR TITLE
chore(playwright): install ffmpeg in keploy-ci-playwright

### DIFF
--- a/keploy-ci-playwright/Dockerfile
+++ b/keploy-ci-playwright/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux; \
     rm -f /tmp/mongodb-database-tools.deb; \
     \
     # ── CI utilities
-    apt-get install -y --no-install-recommends zip zstd; \
+    apt-get install -y --no-install-recommends zip zstd ffmpeg; \
     \
     # ── Cleanup
     apt-get clean; \


### PR DESCRIPTION
Adds ffmpeg to the existing CI utilities apt-get step so consumers that spawn ffmpeg at runtime get a working binary instead of ENOENT.