### PR TITLE
fix(ci): stop creating MinIO ILM rules from the baked cache helper

### DIFF
--- a/keploy-ci-node/minio-cache
+++ b/keploy-ci-node/minio-cache
@@ -80,8 +80,9 @@ case "$ACTION" in
     info "Saving cache: $CACHE_KEY (paths:$DIRS)"
     tar --zstd -cf - $DIRS | mc pipe "$OBJECT"
 
-    # Set 30-day expiry on caches prefix (idempotent, ignores if already set)
-    mc ilm rule add --expire-days 30 "${ALIAS}/${BUCKET}" --prefix "${PREFIX}/" 2>/dev/null || true
+    # NOTE: MinIO lifecycle/retention is managed server-side (canonical rule set on the MinIO instance).
+    # Do NOT add lifecycle rules from CI - the add command is NOT idempotent; each call appends a
+    # duplicate rule and the bucket hit MinIO's 1000-rule cap, breaking retention (2026-08-13 incident).
     info "Cache saved successfully"
     ;;
 

--- a/keploy-ci-playwright/minio-cache
+++ b/keploy-ci-playwright/minio-cache
@@ -80,8 +80,9 @@ case "$ACTION" in
     info "Saving cache: $CACHE_KEY (paths:$DIRS)"
     tar --zstd -cf - $DIRS | mc pipe "$OBJECT"
 
-    # Set 30-day expiry on caches prefix (idempotent, ignores if already set)
-    mc ilm rule add --expire-days 30 "${ALIAS}/${BUCKET}" --prefix "${PREFIX}/" 2>/dev/null || true
+    # NOTE: MinIO lifecycle/retention is managed server-side (canonical rule set on the MinIO instance).
+    # Do NOT add lifecycle rules from CI - the add command is NOT idempotent; each call appends a
+    # duplicate rule and the bucket hit MinIO's 1000-rule cap, breaking retention (2026-08-13 incident).
     info "Cache saved successfully"
     ;;
 


### PR DESCRIPTION
## Why
The `minio-cache` helper baked into the `keploy-ci-node` and `keploy-ci-playwright` images runs `mc ilm rule add ... || true` on every cache save. Despite the comment, this is **not idempotent** — MinIO appends a duplicate lifecycle rule on every call. Accumulated duplicates hit MinIO's hard cap of **1000 rules per bucket** on 2026-08-13, breaking retention enforcement and contributing to the CI storage outage. (Companion PRs already merged: enterprise#2375, api-server#1972, enterprise-ui#1684, playwrightDB#31.)

## What
Remove the `mc ilm rule add` call from both copies of the helper; retention is owned by the server-side canonical rule set on the MinIO instance (applied 2026-08-13).

## ⚠️ Follow-up needed after merge
These scripts are **baked into the CI base images** — the fix only takes effect once the images are rebuilt/pushed and consuming pipelines pick up the new tag. Until then, running pipelines keep re-adding rules (slowly, one prefix).

## Verification
- `grep -rn 'mc ilm'` returns nothing
- `bash -n` passes on both scripts